### PR TITLE
chore: Remove requirement for rdflib

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,9 +2,6 @@ requests==2.20.0
 voluptuous==0.9.3
 unicodecsv==0.14.1
 pysftp==0.2.8
-# TODO: https://github.com/ckan/ckan/issues/5026
-rdflib==4.2.1
-rdflib-jsonld==0.4.0
 geomet==0.3.0
 ckantoolkit==0.0.3
 boto3==1.16.56

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-requests==2.20.0
+requests
 voluptuous==0.9.3
 unicodecsv==0.14.1
 pysftp==0.2.8


### PR DESCRIPTION
Reverting temporary fix: https://github.com/liip/ckanext-switzerland/commit/6f0e769348d7109869eed376f8022435fa88e051 now we are upgrading to Python 3 and CKAN 2.10.