### PR TITLE
refactor: remove ogdch_command plugin

### DIFF
--- a/ckanext/switzerland/plugin.py
+++ b/ckanext/switzerland/plugin.py
@@ -481,19 +481,6 @@ class OgdchPackagePlugin(OgdchLanguagePlugin):
         return search_params
 
 
-class OgdchCommandsPlugin(plugins.SingletonPlugin):
-    plugins.implements(plugins.IActions)
-
-    # IActions
-    def get_actions(self):
-        """
-        Actions that are used by the commands.
-        """
-        return {
-            "ogdch_cleanup_harvestjobs": l.ogdch_cleanup_harvestjobs,
-        }
-
-
 class LangToString(object):
     def __init__(self, attribute):
         self.attribute = attribute

--- a/setup.py
+++ b/setup.py
@@ -83,7 +83,6 @@ setup(
         ogdch_res=ckanext.switzerland.plugin:OgdchResourcePlugin
         ogdch_group=ckanext.switzerland.plugin:OgdchGroupPlugin
         ogdch_org=ckanext.switzerland.plugin:OgdchOrganizationPlugin
-        ogdch_cmd=ckanext.switzerland.plugin:OgdchCommandsPlugin
         dcat_ch_rdf_harvester=ckanext.switzerland.dcat.harvesters:SwissDCATRDFHarvester
         sbb_harvester=ckanext.switzerland.harvester.sbb_harvester:SBBHarvester
         timetable_harvester=ckanext.switzerland.harvester.timetable_harvester:TimetableHarvester


### PR DESCRIPTION
In favor of adding the self-contained ckanext-ogdchcomands-plugin