### PR TITLE
fix: eval resource name

### DIFF
--- a/ckanext/switzerland/helpers.py
+++ b/ckanext/switzerland/helpers.py
@@ -278,7 +278,7 @@ def resource_display_name(resource_dict):
     name = resource_dict.get("name", None)
     description = resource_dict.get("description", None)
     if name:
-        name = parse_json(name)
+        name = parse_json(eval(name))
         if isinstance(name, dict):
             name = get_localized_value(name)
         return name


### PR DESCRIPTION
This makes sure that also old resources that are saved in unicode are displayed correctly