### PR TITLE
docs: Remove misleading comment

### DIFF
--- a/ckanext/switzerland/templates/base.html
+++ b/ckanext/switzerland/templates/base.html
@@ -22,8 +22,6 @@
 
 
 {% block styles %}
-  {# also update the version number in odpch-wp-theme/functions.php odpch_enqueue_scripts
-     and in odpch-wp-theme/style.css #}
   <link rel="stylesheet" href="{{ c.wordpress_css }}">
 
 {% endblock %}


### PR DESCRIPTION
It's no longer required to update the css version number here.