### PR TITLE
fix: check the values-object by checking the type

### DIFF
--- a/ckanext/switzerland/dcat/profiles.py
+++ b/ckanext/switzerland/dcat/profiles.py
@@ -162,7 +162,7 @@ class SwissDCATAPProfile(RDFProfile):
                 if values:
                     # the values can be either a multilang-dict or they are
                     # nested in another iterable (e.g. keywords)
-                    if not hasattr(values, "__iter__"):
+                    if not isinstance(values, list):
                         values = [values]
                     for value in values:
                         self.g.add(


### PR DESCRIPTION
The check for __iter__ does no longer work and ends up adding character after character as single items. By making sure that the current value we are looking at, is not a list already we can add keywords (already in a list) and description and titles as well.