### PR TITLE
fix: Log error more clearly

### DIFF
--- a/ckanext/switzerland/harvester/base_sbb_harvester.py
+++ b/ckanext/switzerland/harvester/base_sbb_harvester.py
@@ -444,7 +444,15 @@ class BaseSBBHarvester(HarvesterBase):
             )
             return False
 
-        # the folder where the file is to be stored
+        # the folder where the file is to be downloaded to
+        if "workingdir" not in obj and "tmpfolder" in obj:
+            self._save_object_error(
+                "Fetch stage received a harvest object that has already been "
+                "processed by this stage: %s" % harvest_object.__dict__,
+                harvest_object,
+                stage,
+            )
+            return False
         tmpfolder = obj.get("workingdir")
         if not tmpfolder:
             self._save_object_error(
@@ -454,7 +462,6 @@ class BaseSBBHarvester(HarvesterBase):
             )
             return False
 
-        # the folder where the file is to be stored
         remotefolder = obj.get("remotefolder")
         if not remotefolder:
             self._save_object_error(

--- a/ckanext/switzerland/harvester/sbb_harvester.py
+++ b/ckanext/switzerland/harvester/sbb_harvester.py
@@ -166,9 +166,6 @@ class SBBHarvester(BaseSBBHarvester):
                 try:
                     existing_dataset = self._get_dataset(self.config["dataset"])
                     package = model.Package.get(existing_dataset["id"])
-                    existing_resources = [
-                        os.path.basename(r.url) for r in package.resources
-                    ]
                     # Request only the resources modified since last harvest job
                     for f in filelist[:]:
                         modified_date = modified_dates.get(f)

--- a/ckanext/switzerland/harvester/sbb_harvester.py
+++ b/ckanext/switzerland/harvester/sbb_harvester.py
@@ -9,7 +9,6 @@ from datetime import datetime
 import voluptuous
 from ckan import model
 from ckan.lib.helpers import json
-from ckan.lib.munge import munge_filename
 from ckan.logic import NotFound
 from ckan.model import Session
 from ckan.plugins.toolkit import config as ckanconf
@@ -178,8 +177,6 @@ class SBBHarvester(BaseSBBHarvester):
                         if (
                             modified_date
                             and modified_date < previous_job.gather_started
-                            and munge_filename(os.path.basename(f))
-                            in existing_resources
                         ):
                             # do not run the harvest for this file
                             filelist.remove(f)

--- a/ckanext/switzerland/tests/helpers/mock_ftp_storage_adapter.py
+++ b/ckanext/switzerland/tests/helpers/mock_ftp_storage_adapter.py
@@ -38,9 +38,8 @@ class MockFTPStorageAdapter(FTPStorageAdapter):
     def get_modified_date(self, filename, folder=None):
         if folder is None:
             folder = self.cwd
-        return self.filesystem.getinfo(os.path.join(folder, filename)).get(
-            "details", "modified"
-        )
+        modified = self.filesystem.getmodified(os.path.join(folder, filename))
+        return modified.replace(tzinfo=None)
 
     def fetch(self, filename, localpath=None):
         if not localpath:

--- a/ckanext/switzerland/tests/test_sbb_harvester.py
+++ b/ckanext/switzerland/tests/test_sbb_harvester.py
@@ -160,8 +160,8 @@ class TestSBBHarvester(BaseSBBHarvesterTests):
     def test_updated_file_before_last_harvester_run(self):
         """
         When modified date of file is older than the last harvester run date, the file
-        should not be harvested again, except when the file is missing in the dataset,
-        that is what we are testing here.
+        should not be harvested again, even if there is no resource with this filename
+        on the dataset.
         """
         filesystem = self.get_filesystem()
         MockFTPStorageAdapter.filesystem = filesystem
@@ -174,7 +174,8 @@ class TestSBBHarvester(BaseSBBHarvesterTests):
 
         dataset = self.get_dataset()
 
-        self.assertEqual(len(dataset["resources"]), 2)
+        self.assertEqual(len(dataset["resources"]), 1)
+        self.assertEqual(dataset["resources"][0]["identifier"], "Didok.csv")
 
     @pytest.mark.usefixtures("with_plugins", "clean_db", "clean_index", "harvest_setup")
     @pytest.mark.ckan_config("ckan.site_url", "http://odp.test")


### PR DESCRIPTION
I don't know why the fetch stage would ever receive a harvest object that it's already processed - this should be handled in ckanext.harvest.queue.fetch_and_import_stages. Hopefully, logging more and clearer data will help debug this.

Also removed an incorrect copy/pasted comment.