### PR TITLE
fix: Add display_name to group schema

### DIFF
--- a/ckanext/switzerland/multilingual_group_scheming.json
+++ b/ckanext/switzerland/multilingual_group_scheming.json
@@ -36,6 +36,12 @@
       "preset": "multilingual_text"
     },
     {
+      "field_name": "display_name",
+      "preset": "multilingual_text",
+      "form_snippet": null,
+      "display_snippet": null
+    },
+    {
       "field_name": "image_url",
       "label": {
         "en": "Image URL",

--- a/ckanext/switzerland/presets.json
+++ b/ckanext/switzerland/presets.json
@@ -60,7 +60,7 @@
       "preset_name": "group_slug",
       "values": {
         "validators": "not_empty unicode_safe name_validator group_name_validator",
-        "form_snipper": "slug.html"
+        "form_snippet": "slug.html"
       }
     },
     {


### PR DESCRIPTION
We don't need to edit this or display it, but it is generated from the title when CKAN creates a group so we need to know it is a multilingual text field.