### PR TITLE
Feat/include line breaks in error messages

### DIFF
--- a/ckanext/switzerland/harvester/base_sbb_harvester.py
+++ b/ckanext/switzerland/harvester/base_sbb_harvester.py
@@ -467,7 +467,8 @@ class BaseSBBHarvester(HarvesterBase):
                 "Fetch stage received a harvest object that has already been "
                 "processed by this stage: %s" % harvest_object.__dict__,
             )
-            return False
+            # returning True so as not to save an error
+            return True
         tmpfolder = obj.get("workingdir")
         if not tmpfolder:
             self._save_object_error(

--- a/ckanext/switzerland/harvester/base_sbb_harvester.py
+++ b/ckanext/switzerland/harvester/base_sbb_harvester.py
@@ -27,7 +27,7 @@ from ckan import model
 from ckan.lib import helpers, search, uploader
 from ckan.lib.helpers import json
 from ckan.lib.munge import munge_filename, munge_name
-from ckan.logic import NotFound, check_access, get_action
+from ckan.logic import NotFound, check_access, get_action, ValidationError
 from ckan.model import Session
 from ckan.plugins.toolkit import config as ckanconf
 from simplejson.scanner import JSONDecodeError
@@ -764,8 +764,16 @@ class BaseSBBHarvester(HarvesterBase):
                 )
                 return False
 
-            # create the dataset
-            dataset = get_action("package_create")(context, package_dict)
+            try:
+                # create the dataset
+                dataset = get_action("package_create")(context, package_dict)
+            except ValidationError as e:
+                self._save_object_error(
+                    f"Validation error creating dataset: {e}",
+                    harvest_object,
+                    stage,
+                )
+                return False
 
             log.info("Created package: %s" % str(dataset["name"]))
 

--- a/ckanext/switzerland/harvester/base_sbb_harvester.py
+++ b/ckanext/switzerland/harvester/base_sbb_harvester.py
@@ -27,7 +27,7 @@ from ckan import model
 from ckan.lib import helpers, search, uploader
 from ckan.lib.helpers import json
 from ckan.lib.munge import munge_filename, munge_name
-from ckan.logic import NotFound, check_access, get_action, ValidationError
+from ckan.logic import NotFound, ValidationError, check_access, get_action
 from ckan.model import Session
 from ckan.plugins.toolkit import config as ckanconf
 from simplejson.scanner import JSONDecodeError

--- a/ckanext/switzerland/harvester/base_sbb_harvester.py
+++ b/ckanext/switzerland/harvester/base_sbb_harvester.py
@@ -973,7 +973,18 @@ class BaseSBBHarvester(HarvesterBase):
 
         # ----------------------------------------------------------------------------
         # reorder resources
-        package = self._get_dataset(harvest_object_data["dataset"])
+        try:
+            package = self._get_dataset(harvest_object_data["dataset"])
+        except NotFound:
+            message = (
+                f"Dataset {harvest_object_data['dataset']} was not found, "
+                f"so not carrying out finalizing tasks. Check other errors for the "
+                f"reason we could not save this dataset."
+            )
+            log.exception(message)
+            self._save_object_error(message, harvest_object, "Import")
+
+            return True
 
         ordered_resources, unmatched_resources = self._get_ordered_resources(package)
 

--- a/ckanext/switzerland/harvester/base_sbb_harvester.py
+++ b/ckanext/switzerland/harvester/base_sbb_harvester.py
@@ -125,6 +125,21 @@ class BaseSBBHarvester(HarvesterBase):
 
     filters = {}
 
+    def _save_gather_error(self, message, job):
+        message = message.replace("\n", "<br>")
+        log.warning(message)
+
+        return super(BaseSBBHarvester, self)._save_gather_error(
+            message=message, job=job
+        )
+
+    def _save_object_error(self, message, object, stage="Fetch"):
+        message = message.replace("\n", "<br>")
+
+        return super(BaseSBBHarvester, self)._save_object_error(
+            message=message, object=object, stage=stage
+        )
+
     def get_remote_folder(self):
         # in the future we want to get directly a path to the folder in the config file
         if self.config.get("environment") is not None:

--- a/ckanext/switzerland/templates/snippets/job_error_summary.html
+++ b/ckanext/switzerland/templates/snippets/job_error_summary.html
@@ -1,0 +1,32 @@
+{#
+Displays a table with a summary of the most common errors for a job
+
+error_summary        - List of dicts with message and error_count
+
+Example:
+
+  {% snippet 'snippets/job_error_summary.html', summary=job.object_error_summary %}
+
+#}
+<table class="table table-striped table-bordered table-condensed harvest-error-summary">
+  <colgroup>
+    <col width="8">
+    <col width="92">
+  </colgroup>
+  <thead>
+    <tr>
+      <th class="count">{{ _('Count') }}</th>
+      <th>{{ _('Message') }}</th>
+    </tr>
+  </thead>
+  <tbody>
+  {% for error in summary %}
+    <tr>
+      <td class="count">{{ error["error_count"] }}</td>
+      <td>{{ error["message"] }}</td>
+    </tr>
+  {% endfor %}
+   </tbody>
+</table>
+
+

--- a/ckanext/switzerland/templates/snippets/job_error_summary.html
+++ b/ckanext/switzerland/templates/snippets/job_error_summary.html
@@ -23,7 +23,7 @@ Example:
   {% for error in summary %}
     <tr>
       <td class="count">{{ error["error_count"] }}</td>
-      <td>{{ error["message"] }}</td>
+      <td>{{ error["message"] | safe }}</td>
     </tr>
   {% endfor %}
    </tbody>

--- a/ckanext/switzerland/templates/source/job/read.html
+++ b/ckanext/switzerland/templates/source/job/read.html
@@ -1,0 +1,95 @@
+{% extends "source/admin_base.html" %}
+
+{% block subtitle %}{{ _('Job Report') }} - {{ super() }}{% endblock %}
+
+{% block primary_content_inner %}
+<div class="module-content">
+
+  <p class="pull-right">
+    {{ h.nav_link(_('Back to job list'), named_route='harvester.job_list', source=harvest_source.name, class_='btn btn-default', icon='arrow-left')}}
+  </p>
+
+  <h1>{{ _('Job Report') }}</h1>
+  {% snippet 'snippets/job_details.html', job=job %}
+
+  {% if job.status == 'Finished' %}
+
+    {% if job.object_error_summary|length == 0 and job.gather_error_summary|length == 0 %}
+      <h2>{{ _('Error Summary') }}</h2>
+      <p class="empty">{{ _('No errors for this job') }}</p>
+    {% else %}
+      <h2>
+        {{ _('Error Summary') }}
+        <small>{{ _('Only the 20 most frequent errors are shown') }}</small>
+      </h2>
+      {% if job.gather_error_summary|length > 0 %}
+        <h3>{{ _('Job Errors') }}</h3>
+        {% snippet 'snippets/job_error_summary.html', summary=job.gather_error_summary %}
+      {% endif %}
+      {% if job.object_error_summary|length > 0 %}
+        <h3>{{ _('Document Errors') }}</h3>
+        {% snippet 'snippets/job_error_summary.html', summary=job.object_error_summary %}
+      {% endif %}
+    {% endif %}
+
+    {% if job_report.gather_errors|length > 0 or job_report.object_errors.keys()|length > 0 %}
+      <h2>
+        {{ _('Error Report') }}
+      </h2>
+      {% if job_report.gather_errors|length > 0 %}
+        <h3>{{ _('Job Errors') }}</h3>
+        <table class="table table-bordered table-hover harvest-error-list">
+          <tbody>
+            {% for error  in job_report.gather_errors %}
+            <tr>
+              <td>
+                  <div class="error">
+                    {{ error.message }}
+                  </div>
+              </td>
+            </tr>
+            {% endfor %}
+          </tbody>
+        </table>
+      {% endif %}
+
+      {% if job_report.object_errors.keys()|length > 0 %}
+        <h3>{{ _('Document Errors') }}
+          <small>{{ job_report.object_errors.keys()|length}} {{ _('documents with errors') }}</small>
+        </h3>
+        <table class="table table-bordered table-hover harvest-error-list">
+          <tbody>
+            {% for harvest_object_id in job_report.object_errors.keys() %}
+            {% set object = job_report.object_errors[harvest_object_id] %}
+            <tr>
+              <td>
+                <span class="btn-group pull-right">
+                  {% if 'original_url' in  object%}
+                    <a href="{{ object.original_url }}" class="btn btn-small">
+                      {{ _('Remote content') }}
+                    </a>
+                  {% endif %}
+                  <a href="{{ h.url_for('harvester.object_show', id=harvest_object_id) }}" class="btn btn-small">
+                    {{ _('Local content') }}
+                  </a>
+
+                </span>
+                <h5>{{ object.guid }}</h5>
+                {% for error in object.errors %}
+                  <div class="error">
+                    {{ error.message }}
+                    {% if error.line %}
+                      <span class="line">(line {{ error.line }})</span>
+                    {% endif %}
+                  </div>
+                {% endfor %}
+              </td>
+            </tr>
+            {% endfor %}
+          </tbody>
+        </table>
+      {% endif %}
+
+  {% endif %}
+  {% endif %}
+{% endblock %}

--- a/ckanext/switzerland/templates/source/job/read.html
+++ b/ckanext/switzerland/templates/source/job/read.html
@@ -44,7 +44,7 @@
             <tr>
               <td>
                   <div class="error">
-                    {{ error.message }}
+                    {{ error.message | safe  }}
                   </div>
               </td>
             </tr>
@@ -77,7 +77,7 @@
                 <h5>{{ object.guid }}</h5>
                 {% for error in object.errors %}
                   <div class="error">
-                    {{ error.message }}
+                    {{+ error.message | safe }}
                     {% if error.line %}
                       <span class="line">(line {{ error.line }})</span>
                     {% endif %}


### PR DESCRIPTION
Something we've wanted for a while now: more readable harvester errors that contain stack traces. This PR would make sure that the line breaks in stack traces are displayed on the harvest job error page.

A couple of considerations:
- the leading whitespace that should be there is not displayed, because Jinja2 removes whitespace from expanded variables by default and I haven't found a way to insist that it's retained. I suspect one of the parent templates is configured to remove whitespace, and this apparently always takes precedence over configuration to keep it. :roll_eyes: That means that stack traces look like this, which is at least an improvement over everything on one line imo:
  ```
  Import stage failed: Traceback (most recent call last):
  File "/srv/app/src_extensions/ckanext-switzerland/ckanext/switzerland/logic.py", line 103, in ogdch_dataset_by_identifier
  return result["results"][0]
  IndexError: list index out of range
  ```
- possibly displaying stack traces this way in both the error summary and error report below it makes the page too long, I'm not sure.