### PR TITLE
Fix resource format and media_type behaviour

### DIFF
--- a/ckanext/switzerland/blueprints.py
+++ b/ckanext/switzerland/blueprints.py
@@ -124,11 +124,13 @@ def resource_download(
     if rsc.get("url_type") == "upload":
         upload = uploader.get_resource_uploader(rsc)
         filepath = upload.get_path(rsc["id"])
-        resp = flask.send_file(filepath, download_name=filename)
+        resp = flask.send_file(
+            filepath,
+            as_attachment=True,
+            attachment_filename=filename,
+            mimetype=rsc.get("mimetype"),
+        )
 
-        if rsc.get("mimetype"):
-            resp.headers["Content-Type"] = rsc["mimetype"]
-        resp.headers["Content-Disposition"] = "attachment"
         signals.resource_download.send(resource_id)
         return resp
 

--- a/ckanext/switzerland/dcat-ap-switzerland_scheming.json
+++ b/ckanext/switzerland/dcat-ap-switzerland_scheming.json
@@ -348,7 +348,7 @@
       "help_text": {
         "de": "Wenn die Ressource eine ZIP-Datei ist, können Sie hier den Medientyp der darin enthaltenen Dateien festlegen",
         "en": "If the resource is a zip file, you can set the media type of the files inside it here",
-        "fr": "Si la ressource est un fichier zip, vous pouvez définir ici le type de médias des fichiers qu'elle contient.",
+        "fr": "Si la ressource est un fichier zip, vous pouvez définir ici le type de médias des fichiers qu'elle contient",
         "it": "Se la risorsa è un file zip, puoi impostare qui il media type dei file al suo interno"
       }
     },

--- a/ckanext/switzerland/dcat-ap-switzerland_scheming.json
+++ b/ckanext/switzerland/dcat-ap-switzerland_scheming.json
@@ -321,10 +321,10 @@
     {
       "field_name": "media_type",
       "label": {
-        "en": "Format",
-        "de": "Format",
-        "fr": "Format",
-        "it": "Formato"
+        "en": "Media type",
+        "de": "Medientyp",
+        "fr": "Type de médias",
+        "it": "Media type"
       }
     },
     {

--- a/ckanext/switzerland/dcat-ap-switzerland_scheming.json
+++ b/ckanext/switzerland/dcat-ap-switzerland_scheming.json
@@ -319,6 +319,16 @@
       "preset": "ogdch_date"
     },
     {
+      "field_name": "format",
+      "label": {
+        "en": "Format",
+        "de": "Format",
+        "fr": "Format",
+        "it": "Formato"
+      },
+      "preset": "resource_format_autocomplete"
+    },
+    {
       "field_name": "media_type",
       "label": {
         "en": "Media type",
@@ -335,16 +345,6 @@
         "fr": "Type de médias (interne)",
         "it": "Media type (interno)"
       }
-    },
-    {
-      "field_name": "format",
-      "label": {
-        "en": "Format",
-        "de": "Format",
-        "fr": "Format",
-        "it": "Formato"
-      },
-      "preset": "resource_format_autocomplete"
     },
     {
       "field_name": "language",

--- a/ckanext/switzerland/dcat-ap-switzerland_scheming.json
+++ b/ckanext/switzerland/dcat-ap-switzerland_scheming.json
@@ -328,6 +328,15 @@
       }
     },
     {
+      "field_name": "mimetype_inner",
+      "label": {
+        "en": "Media type (inner)",
+        "de": "Medientyp (inner)",
+        "fr": "Type de médias (interne)",
+        "it": "Media type (interno)"
+      }
+    },
+    {
       "field_name": "format",
       "label": {
         "en": "Format",

--- a/ckanext/switzerland/dcat-ap-switzerland_scheming.json
+++ b/ckanext/switzerland/dcat-ap-switzerland_scheming.json
@@ -344,6 +344,12 @@
         "de": "Medientyp (inner)",
         "fr": "Type de médias (interne)",
         "it": "Media type (interno)"
+      },
+      "help_text": {
+        "de": "Wenn die Ressource eine ZIP-Datei ist, können Sie hier den Medientyp der darin enthaltenen Dateien festlegen",
+        "en": "If the resource is a zip file, you can set the media type of the files inside it here",
+        "fr": "Si la ressource est un fichier zip, vous pouvez définir ici le type de médias des fichiers qu'elle contient.",
+        "it": "Se la risorsa è un file zip, puoi impostare qui il media type dei file al suo interno"
       }
     },
     {

--- a/ckanext/switzerland/dcat/profiles.py
+++ b/ckanext/switzerland/dcat/profiles.py
@@ -278,7 +278,9 @@ class SwissDCATAPProfile(RDFProfile):
 
             # if media type is not set, use format as fallback
             if not resource_dict.get("media_type") and resource_dict.get("format"):
-                resource_dict["media_type"] = resource_dict["format"]
+                resource_dict["media_type"] = resource_dict["mimetype"] = resource_dict[
+                    "format"
+                ]
 
             # Timestamp fields
             for key, predicate in (

--- a/ckanext/switzerland/dcat/profiles.py
+++ b/ckanext/switzerland/dcat/profiles.py
@@ -493,7 +493,7 @@ class SwissDCATAPProfile(RDFProfile):
             items = [
                 ("status", ADMS.status, None, Literal),
                 ("identifier", DCT.identifier, None, Literal),
-                ("media_type", DCAT.mediaType, None, Literal),
+                ("media_type", DCAT.mediaType, ["mimetype"], Literal),
                 ("spatial", DCT.spatial, None, Literal),
             ]
 

--- a/ckanext/switzerland/harvester/base_sbb_harvester.py
+++ b/ckanext/switzerland/harvester/base_sbb_harvester.py
@@ -395,7 +395,12 @@ class BaseSBBHarvester(HarvesterBase):
         mimetype_inner = None
 
         if format_info[0] == "application/zip":
-            zip_file = zipfile.ZipFile(filename)
+            try:
+                zip_file = zipfile.ZipFile(filename)
+            except zipfile.BadZipFile:
+                log.warning(f"The file {filename} is not a valid zip file")
+                return file_format, mimetype, mimetype_inner
+
             namelist = zip_file.namelist()
 
             for name in namelist:

--- a/ckanext/switzerland/harvester/base_sbb_harvester.py
+++ b/ckanext/switzerland/harvester/base_sbb_harvester.py
@@ -372,15 +372,7 @@ class BaseSBBHarvester(HarvesterBase):
         resource_formats = helpers.resource_formats()
         guess, encoding = mimetypes.guess_type(filename, strict=False)
 
-        # For the guessed mimetype, this gives us the following list:
-        # [
-        #     canonical mimetype lowercased,
-        #     canonical format (uppercase),
-        #     human readable form
-        # ]
-        format_info = resource_formats.get(guess.lower())
-
-        if not format_info:
+        if guess is None or resource_formats.get(guess.lower()) is None:
             log.info(
                 f"Couldn't get a valid resource format from the filename {filename}"
             )
@@ -389,6 +381,14 @@ class BaseSBBHarvester(HarvesterBase):
                 self.default_mimetype,
                 self.default_mimetype_inner,
             )
+
+        # format_info is a list, containing the following values:
+        # [
+        #     canonical mimetype lowercased,
+        #     canonical format (uppercase),
+        #     human readable form
+        # ]
+        format_info = resource_formats.get(guess.lower())
 
         file_format = format_info[1]
         mimetype = format_info[0]
@@ -405,7 +405,7 @@ class BaseSBBHarvester(HarvesterBase):
 
             for name in namelist:
                 guess, encoding = mimetypes.guess_type(name, strict=False)
-                if resource_formats.get(guess.lower()):
+                if guess is not None and resource_formats.get(guess.lower()):
                     # We can only save one value to mimetype_inner, so once we get a
                     # valid mimetype, we can stop looking
                     mimetype_inner = guess

--- a/ckanext/switzerland/harvester/base_sbb_harvester.py
+++ b/ckanext/switzerland/harvester/base_sbb_harvester.py
@@ -655,8 +655,8 @@ class BaseSBBHarvester(HarvesterBase):
             file_filter = self.filters[obj["filter"]]
             obj = file_filter(obj, self.config)
 
-        f = obj.get("file")
-        if not f:
+        filepath = obj.get("file")
+        if not filepath:
             log.error("Invalid file key in harvest object: %s" % obj)
             self._save_object_error("No file to import", harvest_object, stage)
             return False
@@ -694,7 +694,7 @@ class BaseSBBHarvester(HarvesterBase):
             dataset["version"] = now
 
             # check if there is a resource matching the filename in the package
-            old_resource_meta = self.find_resource_in_package(dataset, f)
+            old_resource_meta = self.find_resource_in_package(dataset, filepath)
             if old_resource_meta:
                 log.info(
                     "Found existing resource with this filename: %s"
@@ -830,7 +830,7 @@ class BaseSBBHarvester(HarvesterBase):
         # resource
         # =======================================================================
 
-        log.info("Importing file: %s" % str(f))
+        log.info("Importing file: %s" % str(filepath))
 
         site_url = ckanconf.get("ckan.site_url", None)
         if not site_url:
@@ -839,18 +839,18 @@ class BaseSBBHarvester(HarvesterBase):
             )
             return False
 
-        log.info("Adding %s to package with id %s", str(f), dataset["id"])
+        log.info("Adding %s to package with id %s", str(filepath), dataset["id"])
 
         fp = None
         try:
             try:
-                size = int(os.path.getsize(f))
+                size = int(os.path.getsize(filepath))
             except ValueError:
                 size = None
 
-            fp = open(f, "rb")
+            fp = open(filepath, "rb")
 
-            file_name = os.path.basename(f)
+            file_name = os.path.basename(filepath)
 
             # -----------------------------------------------------
             # create new resource
@@ -871,7 +871,7 @@ class BaseSBBHarvester(HarvesterBase):
 
             resource_meta["identifier"] = file_name
 
-            file_format, mimetype, mimetype_inner = self._get_mimetypes(f)
+            file_format, mimetype, mimetype_inner = self._get_mimetypes(filepath)
             resource_meta["format"] = file_format
             resource_meta["mimetype"] = mimetype
             resource_meta["mimetype_inner"] = mimetype_inner
@@ -918,7 +918,7 @@ class BaseSBBHarvester(HarvesterBase):
 
             log.info("Creating new resource: %s" % str(resource_meta))
 
-            with open(f, "rb") as f:
+            with open(filepath, "rb") as f:
                 stream = io.BytesIO(f.read())
 
             upload = FileStorage(stream=stream, filename=file_name)
@@ -945,7 +945,7 @@ class BaseSBBHarvester(HarvesterBase):
 
             Session.commit()
 
-            log.info("Successfully harvested file %s" % f)
+            log.info("Successfully harvested file %s" % filepath)
 
             # ---------------------------------------------------------------------
 

--- a/ckanext/switzerland/harvester/base_sbb_harvester.py
+++ b/ckanext/switzerland/harvester/base_sbb_harvester.py
@@ -379,7 +379,9 @@ class BaseSBBHarvester(HarvesterBase):
         format_info = helpers.resource_formats().get(guess.lower())
 
         if not format_info:
-            # Couldn't get a valid resource format from the filename: return defaults
+            log.info(
+                f"Couldn't get a valid resource format from the filename {filename}"
+            )
             return (
                 self.default_format,
                 self.default_mimetype,

--- a/ckanext/switzerland/harvester/base_sbb_harvester.py
+++ b/ckanext/switzerland/harvester/base_sbb_harvester.py
@@ -878,7 +878,7 @@ class BaseSBBHarvester(HarvesterBase):
 
             file_format, mimetype, mimetype_inner = self._get_mimetypes(filepath)
             resource_meta["format"] = file_format
-            resource_meta["media_type"] = file_format
+            resource_meta["media_type"] = mimetype
             resource_meta["mimetype"] = mimetype
             resource_meta["mimetype_inner"] = mimetype_inner
 

--- a/ckanext/switzerland/harvester/base_sbb_harvester.py
+++ b/ckanext/switzerland/harvester/base_sbb_harvester.py
@@ -873,6 +873,7 @@ class BaseSBBHarvester(HarvesterBase):
 
             file_format, mimetype, mimetype_inner = self._get_mimetypes(filepath)
             resource_meta["format"] = file_format
+            resource_meta["media_type"] = file_format
             resource_meta["mimetype"] = mimetype
             resource_meta["mimetype_inner"] = mimetype_inner
 

--- a/ckanext/switzerland/harvester/base_sbb_harvester.py
+++ b/ckanext/switzerland/harvester/base_sbb_harvester.py
@@ -71,7 +71,7 @@ class BaseSBBHarvester(HarvesterBase):
     # XML or TXT the default setting is defined to be TXT for files with no extension
     default_format = "TXT"
     default_mimetype = "text/plain"
-    default_mimetype_inner = "text/plain"
+    default_mimetype_inner = None
 
     tmpfolder_prefix = "%d%m%Y-%H%M-"
 

--- a/ckanext/switzerland/plugin.py
+++ b/ckanext/switzerland/plugin.py
@@ -387,7 +387,7 @@ class OgdchPackagePlugin(OgdchLanguagePlugin):
             extract_title(r) for r in validated_dict["resources"]
         ]
         search_data["res_format"] = [
-            r["media_type"] for r in validated_dict["resources"] if "media_type" in r
+            r["format"] for r in validated_dict["resources"] if "format" in r
         ]
         search_data["res_rights"] = [
             sh.simplify_terms_of_use(r.get("rights", ""))

--- a/ckanext/switzerland/templates/scheming/package/resource_read.html
+++ b/ckanext/switzerland/templates/scheming/package/resource_read.html
@@ -6,7 +6,6 @@
     'title',
     'url',
     'issued',
-    'media_type',
     'download_url',
     'rights',
     'license',

--- a/ckanext/switzerland/templates/snippets/package_item.html
+++ b/ckanext/switzerland/templates/snippets/package_item.html
@@ -66,10 +66,10 @@ Example:
           {% block resources_outer %}
             <ul class="dataset-resources list-inline">
               {% block resources_inner %}
-                {% for media_type in h.dict_list_reduce(package.resources, 'media_type') %}
+                {% for format in h.dict_list_reduce(package.resources, 'format') %}
                 <li>
-                  {% set media_type_truncated = h.truncate(media_type, 30) %}
-                  <small><span class="label label-default" title="{{ media_type }}">{{ media_type_truncated.upper() }}</span></small>
+                  {% set format_truncated = h.truncate(format, 30) %}
+                  <small><span class="label label-default" title="{{ format }}">{{ format_truncated.upper() }}</span></small>
                 </li>
                 {% endfor %}
               {% endblock %}

--- a/ckanext/switzerland/tests/test_sbb_harvester.py
+++ b/ckanext/switzerland/tests/test_sbb_harvester.py
@@ -366,6 +366,10 @@ class TestSBBHarvester(BaseSBBHarvesterTests):
         dataset = self.get_dataset()
         self.assertEqual(len(dataset["resources"]), 3)
 
+        result = get_action("package_search")({}, {"facet.field": ["res_format"]})
+        res_format_facet = result["facets"]["res_format"]
+        self.assertDictEqual(res_format_facet, {"CSV": 1, "JSON": 1, "XML": 1})
+
         csv_resource = next(
             (
                 resource

--- a/ckanext/switzerland/tests/test_sbb_harvester.py
+++ b/ckanext/switzerland/tests/test_sbb_harvester.py
@@ -354,6 +354,64 @@ class TestSBBHarvester(BaseSBBHarvesterTests):
         self.assertEqual(package.resources[2].extras["identifier"], "20160902.csv")
 
     @pytest.mark.usefixtures("with_plugins", "clean_db", "clean_index", "harvest_setup")
+    def test_resource_formats(self):
+        filesystem = self.get_filesystem(filename="20160901.csv")
+        MockFTPStorageAdapter.filesystem = filesystem
+        path = os.path.join(data.environment, data.folder, "20160901.xml")
+        filesystem.writetext(path, data.dataset_content_2)
+        path = os.path.join(data.environment, data.folder, "20160901.json")
+        filesystem.writetext(path, data.dataset_content_3)
+        self.run_harvester(ftp_server="testserver")
+
+        dataset = self.get_dataset()
+        self.assertEqual(len(dataset["resources"]), 3)
+
+        csv_resource = next(
+            (
+                resource
+                for resource in dataset["resources"]
+                if resource["identifier"] == "20160901.csv"
+            ),
+            None,
+        )
+        self.assertEqual(csv_resource["identifier"], "20160901.csv")
+        self.assertEqual(csv_resource["format"], "CSV")
+        self.assertEqual(csv_resource["media_type"], "text/csv")
+        self.assertEqual(csv_resource["mimetype"], "text/csv")
+        # mimetype_inner is None, so CKAN doesn't save it on the resource
+        self.assertNotIn("mimetype_inner", csv_resource)
+
+        xml_resource = next(
+            (
+                resource
+                for resource in dataset["resources"]
+                if resource["identifier"] == "20160901.xml"
+            ),
+            None,
+        )
+        self.assertEqual(xml_resource["identifier"], "20160901.xml")
+        self.assertEqual(xml_resource["format"], "XML")
+        self.assertEqual(xml_resource["media_type"], "application/xml")
+        self.assertEqual(xml_resource["mimetype"], "application/xml")
+        # mimetype_inner is None, so CKAN doesn't save it on the resource
+        self.assertNotIn("mimetype_inner", xml_resource)
+
+        json_resource = next(
+            (
+                resource
+                for resource in dataset["resources"]
+                if resource["identifier"] == "20160901.json"
+            ),
+            None,
+        )
+        self.assertEqual(json_resource["identifier"], "20160901.json")
+        self.assertEqual(json_resource["format"], "JSON")
+        self.assertEqual(json_resource["media_type"], "application/json")
+        self.assertEqual(json_resource["mimetype"], "application/json")
+        # mimetype_inner is None, so CKAN doesn't save it on the resource
+        self.assertNotIn("mimetype_inner", json_resource)
+
+    @pytest.mark.usefixtures("with_plugins", "clean_db", "clean_index", "harvest_setup")
     def test_filter_regex(self):
         filesystem = self.get_filesystem(filename="File.zip")
         MockFTPStorageAdapter.filesystem = filesystem


### PR DESCRIPTION
- set filename when downloading a resource file (useful if it can't be taken from the url, i.e. with the dataset permalink)
- set resource `media_type`, `mimetype` and `mimetype_inner` correctly when harvesting resources
  - `mimetype` is the CKAN default equivalent of our field `media_type`. We set it explicitly (to the same value) for consistency.
  - `mimetype_inner` is the CKAN field representing the media type of files inside a zip file.
- fix the label of the resource field `media_type`
- enable display and manual editing of the resource fields `media_type` and `mimetype_inner` on the website
- use the resource field `format` to generate the `res_format` field on the dataset when indexing, not `media_type`
- use the resource field `format` to set the format label on datasets in a list
  - for both these points, `format` should be used as it is short and readable (e.g. "TXT", "XLSX", "ZIP")
- minor consistency fixes in parsing datasets from and exporting datasets to RDF graphs