### PR TITLE
fix: Re-include parent links block in base.html template

### DIFF
--- a/ckanext/switzerland/templates/base.html
+++ b/ckanext/switzerland/templates/base.html
@@ -32,6 +32,7 @@
       g.async=true; g.src='https://stats.opentransportdata.swiss/js/container_agVN5ZM7.js'; s.parentNode.insertBefore(g,s);
     })();
   </script>
+  {{ super() }}
 {% endblock %}
 
 


### PR DESCRIPTION
The ckan core base.html template includes the link to the favicon, which we need.