### PR TITLE
fix: Always get current datetime in UTC timezone

### DIFF
--- a/ckanext/switzerland/harvester/base_sbb_harvester.py
+++ b/ckanext/switzerland/harvester/base_sbb_harvester.py
@@ -677,7 +677,7 @@ class BaseSBBHarvester(HarvesterBase):
 
         context = {"model": model, "session": Session, "user": self._get_user_name()}
 
-        now = datetime.now().isoformat()
+        now = datetime.utcnow().isoformat()
 
         # =======================================================================
         # package
@@ -1068,7 +1068,7 @@ class BaseSBBHarvester(HarvesterBase):
         else:
             permalink = None
 
-        now = datetime.now().isoformat()
+        now = datetime.utcnow().isoformat()
         get_action("package_patch")(
             context,
             {

--- a/ckanext/switzerland/harvester/sbb_harvester.py
+++ b/ckanext/switzerland/harvester/sbb_harvester.py
@@ -116,7 +116,7 @@ class SBBHarvester(BaseSBBHarvester):
                     storage.create_local_dir(tmpdirbase)
 
                 # set prefix for tmp folder
-                prefix = datetime.now().strftime(self.tmpfolder_prefix)
+                prefix = datetime.utcnow().strftime(self.tmpfolder_prefix)
                 # save the folder path where the files are to be downloaded
                 # all parts following the first one must be relative paths
 

--- a/ckanext/switzerland/harvester/timetable_harvester.py
+++ b/ckanext/switzerland/harvester/timetable_harvester.py
@@ -116,7 +116,7 @@ class TimetableHarvester(SBBHarvester):
                     storage.create_local_dir(tmpdirbase)
 
                 # set prefix for tmp folder
-                prefix = datetime.now().strftime(self.tmpfolder_prefix)
+                prefix = datetime.utcnow().strftime(self.tmpfolder_prefix)
                 # save the folder path where the files are to be downloaded
                 # all parts following the first one must be relative paths
 

--- a/ckanext/switzerland/helpers.py
+++ b/ckanext/switzerland/helpers.py
@@ -365,7 +365,6 @@ def get_resource_display_items(res, exclude_fields, schema):
     resource = tk.get_action("resource_show")(
         context, {"id": res.get("id"), "use_default_schema": True}
     )
-    convert_datetimes_for_display(resource)
 
     resource["byte_size"] = resource["size"]
 
@@ -502,39 +501,6 @@ def _get_datetime_from_isoformat_string(dt_string):
     except ValueError:
         log.warning(f"Error getting a datetime from isoformat string: {dt_string}")
         return False
-
-
-def convert_datetimes_for_display(dataset_or_resource_dict):
-    """Converts all datetimes in a dataset or resource to UTC, without time zone info
-    attached. CKAN's "automatic-local-datetime" HTML class and JS helper will then
-    display them in the user's local time zone.
-
-    CKAN stores all datetimes as UTC by default. For our custom datetime fields, we use
-    the server time zone (Europe/Zurich), so they have to be converted to UTC.
-    """
-    for field in CUSTOM_DATETIME_FIELDS:
-        dt = _get_datetime_from_isoformat_string(dataset_or_resource_dict.get(field))
-        if dt is False:
-            continue
-
-        dt_zh = dt.replace(tzinfo=ZURICH)
-        dt_utc = dt_zh.astimezone(UTC)
-        dataset_or_resource_dict[field] = dt_utc.replace(tzinfo=None).isoformat()
-
-    if dataset_or_resource_dict.get("extras"):
-        for extra in dataset_or_resource_dict["extras"]:
-            if extra["key"] in CUSTOM_DATETIME_FIELDS:
-                dt = _get_datetime_from_isoformat_string(extra["value"])
-                if dt is False:
-                    continue
-
-                dt_zh = dt.replace(tzinfo=ZURICH)
-                dt_utc = dt_zh.astimezone(UTC)
-                extra["value"] = dt_utc.replace(tzinfo=None).isoformat()
-
-    if dataset_or_resource_dict.get("resources"):
-        for resource in dataset_or_resource_dict["resources"]:
-            convert_datetimes_for_display(resource)
 
 
 def convert_datetimes_for_api(dataset_or_resource_dict):

--- a/ckanext/switzerland/helpers.py
+++ b/ckanext/switzerland/helpers.py
@@ -22,13 +22,11 @@ from simplejson import JSONDecodeError
 
 log = logging.getLogger(__name__)
 
-CKAN_DATETIME_FIELDS = [
+DATETIME_FIELDS = [
     "created",
     "last_modified",
     "metadata_created",
     "metadata_modified",
-]
-CUSTOM_DATETIME_FIELDS = [
     "issued",
     "modified",
     "version",
@@ -507,26 +505,15 @@ def convert_datetimes_for_api(dataset_or_resource_dict):
     """Calculates the time of a datetime in the Europe/Zurich time zone and outputs the
     value as isoformat, with time zone info.
 
-    CKAN stores all datetimes as UTC by default, so they have to be converted to
-    Europe/Zurich and have the time zone info added. For our custom datetime fields, we
-    use the server time zone, so they are already in Europe/Zurich. We just have to add
-    the time zone info.
+    All datetimes are stored in the database and Solr as UTC and have no time zone info.
     """
-    for field in CKAN_DATETIME_FIELDS:
+    for field in DATETIME_FIELDS:
         dt = _get_datetime_from_isoformat_string(dataset_or_resource_dict.get(field))
         if dt is False:
             continue
 
         dt_utc = dt.replace(tzinfo=UTC)
         dt_zh = dt_utc.astimezone(ZURICH)
-        dataset_or_resource_dict[field] = dt_zh.isoformat()
-
-    for field in CUSTOM_DATETIME_FIELDS:
-        dt = _get_datetime_from_isoformat_string(dataset_or_resource_dict.get(field))
-        if dt is False:
-            continue
-
-        dt_zh = dt.replace(tzinfo=ZURICH)
         dataset_or_resource_dict[field] = dt_zh.isoformat()
 
     if dataset_or_resource_dict.get("resources"):

--- a/ckanext/switzerland/plugin.py
+++ b/ckanext/switzerland/plugin.py
@@ -158,7 +158,7 @@ class OgdchLanguagePlugin(plugins.SingletonPlugin):
         # Do not change the resulting dict for API requests and form saves
         # _package_reduce_to_requested_language removes all translation dicts needed
         # to show the form on resource_edit, so we skip it here
-        if sh.request_is_api_request() or toolkit.request.path == "POST":
+        if sh.request_is_api_request() or toolkit.request.method == "POST":
             return pkg_dict
 
         # replace langauge dicts with requested language strings

--- a/ckanext/switzerland/plugin.py
+++ b/ckanext/switzerland/plugin.py
@@ -91,7 +91,6 @@ class OgdchPlugin(plugins.SingletonPlugin):
             "render_description": sh.render_description,
             "get_resource_display_items": sh.get_resource_display_items,
             "convert_datetimes_for_api": sh.convert_datetimes_for_api,
-            "convert_datetimes_for_display": sh.convert_datetimes_for_display,
             "request_is_api_request": sh.request_is_api_request,
             # monkey patch template helpers to return translated names/titles
             "dataset_display_name": sh.dataset_display_name,
@@ -329,8 +328,6 @@ class OgdchPackagePlugin(OgdchLanguagePlugin):
         """
         if not self.is_supported_package_type(pkg_dict):
             return pkg_dict
-
-        sh.convert_datetimes_for_display(pkg_dict)
 
         return super(OgdchPackagePlugin, self).before_view(pkg_dict)
 

--- a/ckanext/switzerland/plugin.py
+++ b/ckanext/switzerland/plugin.py
@@ -350,10 +350,10 @@ class OgdchPackagePlugin(OgdchLanguagePlugin):
                     pkg_dict["organization"][field]
                 )
 
-        if sh.request_is_api_request():
+        if sh.request_is_api_request() and not toolkit.request.method == "POST":
             # We want to convert datetimes to Europe/Zurich and include the time zone
             # information, but only when returning the dataset via the API, not when
-            # handling it internally.
+            # handling it internally or updating the dataset.
             sh.convert_datetimes_for_api(pkg_dict)
 
         return pkg_dict

--- a/ckanext/switzerland/tests/test_plugin.py
+++ b/ckanext/switzerland/tests/test_plugin.py
@@ -26,24 +26,23 @@ class TestOgdchPackagePlugin(object):
     )
     def _create_dataset(self):
         """Create a dataset with a resource and set datetime fields to known values.
+        All datetimes are saved in the database and Solr as UTC.
 
-        We mock the current time (in UTC), because we can't specify values for
-        metadata_created, metadata_modified and created otherwise. CKAN sets those
-        values to datetime.datetime.utcnow() when creating or modifying a
-        dataset/resource.
-
-        We set our custom fields (issued, modified, version) to values in the
-        Europe/Zurich time zone.
+        Fields that CKAN sets to the current UTC time when creating/updating a dataset:
+        - dataset metadata_created
+        - dataset metadata_modified
+        - resource created
+        - resource last_modified
+        - resource metadata_modified
         """
+        # Fields where we set a value directly when creating/updating a dataset/resource
         dataset_datetime_fields = {
             "issued": "2022-04-18T12:00:00",
             "modified": "2022-04-18T12:30:00",
             "version": "2022-04-18T12:30:00",
         }
-        # last_modified is a CKAN default field, but we can set its value directly,
-        # unlike the other CKAN default fields
         resource_datetime_fields = {
-            "last_modified": "2022-04-20T14:15:00",
+            "last_modified": "2022-04-18T12:30:00",
             "issued": "2022-04-18T12:00:00",
             "modified": "2022-04-18T12:30:00",
         }
@@ -98,15 +97,15 @@ class TestOgdchPackagePlugin(object):
 
         assert pkg_dict["metadata_created"] == "2022-04-20T16:15:00+02:00"
         assert pkg_dict["metadata_modified"] == "2022-04-20T16:15:00+02:00"
-        assert pkg_dict["issued"] == "2022-04-18T12:00:00+02:00"
-        assert pkg_dict["modified"] == "2022-04-18T12:30:00+02:00"
-        assert pkg_dict["version"] == "2022-04-18T12:30:00+02:00"
+        assert pkg_dict["issued"] == "2022-04-18T14:00:00+02:00"
+        assert pkg_dict["modified"] == "2022-04-18T14:30:00+02:00"
+        assert pkg_dict["version"] == "2022-04-18T14:30:00+02:00"
 
         assert resource_dict["created"] == "2022-04-20T16:15:00+02:00"
         assert resource_dict["metadata_modified"] == "2022-04-20T16:15:00+02:00"
-        assert resource_dict["last_modified"] == "2022-04-20T16:15:00+02:00"
-        assert resource_dict["issued"] == "2022-04-18T12:00:00+02:00"
-        assert resource_dict["modified"] == "2022-04-18T12:30:00+02:00"
+        assert resource_dict["last_modified"] == "2022-04-18T14:30:00+02:00"
+        assert resource_dict["issued"] == "2022-04-18T14:00:00+02:00"
+        assert resource_dict["modified"] == "2022-04-18T14:30:00+02:00"
 
     @responses.activate
     def test_get_correct_datetime_format_for_dataset_display(self, app):
@@ -124,9 +123,9 @@ class TestOgdchPackagePlugin(object):
         assert (
             last_updated["data-datetime"]
             == modified["data-datetime"]
-            == "2022-04-18T10:30:00+0000"
+            == "2022-04-18T12:30:00+0000"
         )
-        assert issued["data-datetime"] == "2022-04-18T10:00:00+0000"
+        assert issued["data-datetime"] == "2022-04-18T12:00:00+0000"
 
     @responses.activate
     def test_get_correct_datetime_format_for_resource_display(self, app):
@@ -154,4 +153,4 @@ class TestOgdchPackagePlugin(object):
 
         # modified date should be in UTC
         modified = soup.find("dt", text="Modified date").findNext("dd").find("span")
-        assert modified["data-datetime"] == "2022-04-18T10:30:00+0000"
+        assert modified["data-datetime"] == "2022-04-18T12:30:00+0000"

--- a/ckanext/switzerland/tests/test_sbb_harvester.py
+++ b/ckanext/switzerland/tests/test_sbb_harvester.py
@@ -5,10 +5,10 @@ from time import sleep
 from zoneinfo import ZoneInfo
 
 import pytest
+import time_machine
 from ckan.lib.munge import munge_name
 from ckan.logic import NotFound, get_action
 from mock import patch
-import time_machine
 
 from ckanext.harvest import model as harvester_model
 from ckanext.switzerland.harvester.sbb_harvester import SBBHarvester

--- a/ckanext/switzerland/tests/test_sbb_harvester.py
+++ b/ckanext/switzerland/tests/test_sbb_harvester.py
@@ -12,7 +12,6 @@ import time_machine
 
 from ckanext.harvest import model as harvester_model
 from ckanext.switzerland.harvester.sbb_harvester import SBBHarvester
-from ckanext.switzerland.helpers import DATETIME_FIELDS
 from ckanext.switzerland.tests.helpers.mock_ftp_storage_adapter import (
     MockFTPStorageAdapter,
     MockStorageAdapterFactory,


### PR DESCRIPTION
All datetimes saved by CKAN are in the UTC timezone (without TZ info). This is because Solr only accepts datetimes in UTC. We should do the same.