### PR TITLE
Fix/fix harvester error for migration

### DIFF
--- a/ckanext/switzerland/harvester/base_sbb_harvester.py
+++ b/ckanext/switzerland/harvester/base_sbb_harvester.py
@@ -501,8 +501,9 @@ class BaseSBBHarvester(HarvesterBase):
                 "Fetch stage received a harvest object that has already been "
                 "processed by this stage: %s" % harvest_object.__dict__,
             )
-            # returning True so as not to save an error
-            return True
+            # returning "unchanged" so as not to save an error or continue to import
+            # stage
+            return "unchanged"
         tmpfolder = obj.get("workingdir")
         if not tmpfolder:
             self._save_object_error(


### PR DESCRIPTION
Sometimes the fetch process gets a harvest object from the queue that has already been processed. This happens after all of a job's harvest objects have been processed, including the one that deletes the temp folder storing files to add as resources. If this harvest object gets passed to the import stage, we get an error that it cannot be processed because the folder does not exist.

To prevent this, the fetch stage should return 'unchanged', which prevents the harvest object being passed on to the import stage.

We have not figured out how these harvest objects get passed on to the fetch process a second time, after they should have been saved as complete and removed from the queue, so this is still just a workaround.