### PR TITLE
fix: Return a 404 if resource is not found

### DIFF
--- a/ckanext/switzerland/blueprints.py
+++ b/ckanext/switzerland/blueprints.py
@@ -56,12 +56,14 @@ def resource_download(
     """
     context: Context = {"user": current_user.name, "auth_user_obj": current_user}
 
-    try:
-        resource_obj = model.Resource.get(resource_id)
-        rsc = resource_dictize(resource_obj, {"model": model})
-        get_action("package_show")(context, {"id": id})
-    except NotFound:
+    resource_obj = model.Resource.get(resource_id)
+    if resource_obj is None:
         return base.abort(404, _("Resource not found"))
+
+    rsc = resource_dictize(resource_obj, {"model": model})
+
+    try:
+        get_action("package_show")(context, {"id": id})
     except NotAuthorized:
         return base.abort(403, _("Not authorized to download resource"))
 


### PR DESCRIPTION
The CKAN core view that this is copied from calls the action 'resource_show' to get the resource. We get it from the db directly, which does not throw a NotFound exception if the resource is not there.