### PR TITLE
fix: Pin paramiko version to 3.5.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 boto3==1.28.21
 ckantoolkit==0.0.7
 geomet==1.0.0
+paramiko==3.5.1
 pysftp==0.2.9
 requests==2.31.0
 routes==2.5.1


### PR DESCRIPTION
pysftp 0.2.9 requires paramiko>=1.17, but paramiko 4.0.0 just came out and is a breaking change. Let's pin paramiko to the latest version that works for us.