### PR TITLE
feat: Temporarily make resource license field non-required

### DIFF
--- a/ckanext/switzerland/dcat-ap-switzerland_scheming.json
+++ b/ckanext/switzerland/dcat-ap-switzerland_scheming.json
@@ -339,7 +339,6 @@
       "field_name": "license",
       "preset": "select",
       "choices_helper": "ogdch_get_license_choices",
-      "required": true,
       "label": {
         "en": "License (Terms of use)",
         "de": "Lizenz (Nutzungsbedingungen)",


### PR DESCRIPTION
Required so that we can migrate existing data. Otherwise, patching a resource to add the license value is blocked by a validation error if any other resources on the same package don't have the license set.