### PR TITLE
feat: copy format-field from existing resource of the same name

### DIFF
--- a/ckanext/switzerland/harvester/base_sbb_harvester.py
+++ b/ckanext/switzerland/harvester/base_sbb_harvester.py
@@ -703,6 +703,7 @@ class BaseSBBHarvester(HarvesterBase):
 
         old_resource_id = None
         old_resource_meta = {}
+        copy_format_from_old_resource = False
 
         source_org_id = model.Package.get(harvest_object.source.id).owner_org
         source_org = get_action("organization_show")(context, {"id": source_org_id})
@@ -720,6 +721,7 @@ class BaseSBBHarvester(HarvesterBase):
 
             # check if there is a resource matching the filename in the package
             old_resource_meta = self.find_resource_in_package(dataset, filepath)
+            copy_format_from_old_resource = bool(old_resource_meta)
             if old_resource_meta:
                 log.info(
                     "Found existing resource with this filename: %s"
@@ -922,8 +924,9 @@ class BaseSBBHarvester(HarvesterBase):
                 "coverage",
                 "description",
                 "relations",
-                "format",
             ]
+            if copy_format_from_old_resource:
+                fields_from_old_resource_meta.append("format")
             for field in fields_from_old_resource_meta:
                 if old_resource_meta.get(field):
                     resource_meta[field] = old_resource_meta.get(field)

--- a/ckanext/switzerland/harvester/base_sbb_harvester.py
+++ b/ckanext/switzerland/harvester/base_sbb_harvester.py
@@ -703,7 +703,9 @@ class BaseSBBHarvester(HarvesterBase):
 
         old_resource_id = None
         old_resource_meta = {}
-        copy_format_from_old_resource = False
+        # ``format`` is only copied when an incoming resource replaces an existing
+        # resource (same download filename / URL basename).
+        copy_format_from_same_filename_resource = False
 
         source_org_id = model.Package.get(harvest_object.source.id).owner_org
         source_org = get_action("organization_show")(context, {"id": source_org_id})
@@ -721,7 +723,7 @@ class BaseSBBHarvester(HarvesterBase):
 
             # check if there is a resource matching the filename in the package
             old_resource_meta = self.find_resource_in_package(dataset, filepath)
-            copy_format_from_old_resource = bool(old_resource_meta)
+            copy_format_from_same_filename_resource = bool(old_resource_meta)
             if old_resource_meta:
                 log.info(
                     "Found existing resource with this filename: %s"
@@ -891,6 +893,8 @@ class BaseSBBHarvester(HarvesterBase):
                         "Using existing resource to copy metadata from: %s"
                         % str(old_resource_meta)
                     )
+
+            copy_format_from_old_resource = copy_format_from_same_filename_resource
 
             resource_meta = self.resource_dict_meta
 

--- a/ckanext/switzerland/harvester/base_sbb_harvester.py
+++ b/ckanext/switzerland/harvester/base_sbb_harvester.py
@@ -894,8 +894,6 @@ class BaseSBBHarvester(HarvesterBase):
                         % str(old_resource_meta)
                     )
 
-            copy_format_from_old_resource = copy_format_from_same_filename_resource
-
             resource_meta = self.resource_dict_meta
 
             resource_meta["identifier"] = file_name
@@ -929,7 +927,7 @@ class BaseSBBHarvester(HarvesterBase):
                 "description",
                 "relations",
             ]
-            if copy_format_from_old_resource:
+            if copy_format_from_same_filename_resource:
                 fields_from_old_resource_meta.append("format")
             for field in fields_from_old_resource_meta:
                 if old_resource_meta.get(field):

--- a/ckanext/switzerland/harvester/base_sbb_harvester.py
+++ b/ckanext/switzerland/harvester/base_sbb_harvester.py
@@ -922,6 +922,7 @@ class BaseSBBHarvester(HarvesterBase):
                 "coverage",
                 "description",
                 "relations",
+                "format",
             ]
             for field in fields_from_old_resource_meta:
                 if old_resource_meta.get(field):

--- a/ckanext/switzerland/tests/base_ftp_harvester_tests.py
+++ b/ckanext/switzerland/tests/base_ftp_harvester_tests.py
@@ -91,8 +91,8 @@ class BaseSBBHarvesterTests(unittest.TestCase):
         fs.settimes(path, modified=datetime(2000, 1, 1))
         return fs
 
-    def assert_resource_format_ignore_case(self, value, expected, msg=None):
-        """Assert resource ``format`` equals *expected*, case-insensitively."""
+    def assert_equal_ignore_case(self, value, expected, msg=None):
+        """Assert value, case-insensitively."""
         self.assertEqual(
             (value or "").strip().lower(),
             (expected or "").strip().lower(),

--- a/ckanext/switzerland/tests/base_ftp_harvester_tests.py
+++ b/ckanext/switzerland/tests/base_ftp_harvester_tests.py
@@ -91,6 +91,14 @@ class BaseSBBHarvesterTests(unittest.TestCase):
         fs.settimes(path, modified=datetime(2000, 1, 1))
         return fs
 
+    def assert_resource_format_ignore_case(self, value, expected, msg=None):
+        """Assert resource ``format`` equals *expected*, case-insensitively."""
+        self.assertEqual(
+            (value or "").strip().lower(),
+            (expected or "").strip().lower(),
+            msg,
+        )
+
     def assert_dataset_data(self, dataset_data, **kwargs):
         expected_data = {
             "identifier": "Dataset",

--- a/ckanext/switzerland/tests/test_sbb_harvester.py
+++ b/ckanext/switzerland/tests/test_sbb_harvester.py
@@ -165,7 +165,7 @@ class TestSBBHarvester(BaseSBBHarvesterTests):
         self.assertEqual(len(dataset["resources"]), 1)
         resource = dataset["resources"][0]
         self.assertEqual(resource["identifier"], data.filename)
-        self.assert_resource_format_ignore_case(resource["format"], "geojson")
+        self.assert_equal_ignore_case(resource["format"], "geojson")
 
     def test_new_resource_keeps_mime_format_with_fallback_metadata(self):
         """With no same-filename resource, ``format`` comes from MIME; other metadata may still be copied from a template resource."""
@@ -184,7 +184,7 @@ class TestSBBHarvester(BaseSBBHarvesterTests):
         new_res = next(
             r for r in dataset["resources"] if r["identifier"] == data.filename
         )
-        self.assert_resource_format_ignore_case(new_res["format"], "csv")
+        self.assert_equal_ignore_case(new_res["format"], "csv")
         self.assertEqual(
             new_res["rights"],
             res["rights"],
@@ -228,7 +228,7 @@ class TestSBBHarvester(BaseSBBHarvesterTests):
         self.assertEqual(len(dataset["resources"]), 3)
         by_identifier = {r["identifier"]: r for r in dataset["resources"]}
 
-        self.assert_resource_format_ignore_case(
+        self.assert_equal_ignore_case(
             by_identifier[data.filename]["format"],
             "csv",
             "Harvested file should use MIME format, not the template resource format",
@@ -243,7 +243,7 @@ class TestSBBHarvester(BaseSBBHarvesterTests):
             "XML",
             "Another resource on the dataset must not be updated by the harvest import",
         )
-        self.assert_resource_format_ignore_case(
+        self.assert_equal_ignore_case(
             by_identifier["AAAResource"]["format"],
             "geojson",
         )
@@ -285,7 +285,7 @@ class TestSBBHarvester(BaseSBBHarvesterTests):
         self.assertEqual(len(dataset["resources"]), 2)
         by_identifier = {r["identifier"]: r for r in dataset["resources"]}
 
-        self.assert_resource_format_ignore_case(
+        self.assert_equal_ignore_case(
             by_identifier[data.filename]["format"],
             "geojson",
         )

--- a/ckanext/switzerland/tests/test_sbb_harvester.py
+++ b/ckanext/switzerland/tests/test_sbb_harvester.py
@@ -6,8 +6,9 @@ from zoneinfo import ZoneInfo
 
 import pytest
 import time_machine
-from ckan.lib.munge import munge_name
+from ckan.lib.munge import munge_filename, munge_name
 from ckan.logic import NotFound, get_action
+from ckan.tests import factories
 from mock import patch
 
 from ckanext.harvest import model as harvester_model
@@ -146,6 +147,142 @@ class TestSBBHarvester(BaseSBBHarvesterTests):
         self.assertEqual(
             resource["license"],
             "http://dcat-ap.ch/vocabulary/licenses/terms_open",
+        )
+
+    def test_replace_same_filename_preserves_format_from_old_resource(self):
+        """When a file replaces an existing resource, ``format`` is copied from the old resource."""
+        dataset = data.dataset()
+        res = data.resource(dataset=dataset, filename=data.filename)
+        get_action("resource_patch")(
+            {"user": factories.Sysadmin()["name"]},
+            {"id": res["id"], "format": "GEOJSON"},
+        )
+
+        MockFTPStorageAdapter.filesystem = self.get_filesystem()
+        self.run_harvester(ftp_server="testserver")
+
+        dataset = self.get_dataset()
+        self.assertEqual(len(dataset["resources"]), 1)
+        resource = dataset["resources"][0]
+        self.assertEqual(resource["identifier"], data.filename)
+        self.assert_resource_format_ignore_case(resource["format"], "geojson")
+
+    def test_new_resource_copies_format_from_fallback_old_resource(self):
+        """With no matching resource for the filename, ``format`` is taken from the first existing resource."""
+        dataset = data.dataset()
+        res = data.resource(dataset=dataset)
+        get_action("resource_patch")(
+            {"user": factories.Sysadmin()["name"]},
+            {"id": res["id"], "format": "GEOJSON"},
+        )
+
+        MockFTPStorageAdapter.filesystem = self.get_filesystem()
+        self.run_harvester(ftp_server="testserver")
+
+        dataset = self.get_dataset()
+        self.assertEqual(len(dataset["resources"]), 2)
+        new_res = next(
+            r for r in dataset["resources"] if r["identifier"] == data.filename
+        )
+        self.assert_resource_format_ignore_case(new_res["format"], "geojson")
+
+    def test_copied_metadata_only_affects_new_harvested_resource(self):
+        """Only the resource created from the FTP file gets metadata copied from the fallback; other resources are unchanged."""
+        dataset = data.dataset()
+        aaa = data.resource(dataset=dataset)
+        get_action("resource_patch")(
+            {"user": factories.Sysadmin()["name"]},
+            {"id": aaa["id"], "format": "GEOJSON"},
+        )
+
+        factories.Resource(
+            package_id=dataset["id"],
+            identifier="Other.csv",
+            format="XML",
+            title={"de": "Other", "en": "Other", "fr": "Other", "it": "Other"},
+            name={"de": "Other", "en": "Other", "fr": "Other", "it": "Other"},
+            description={
+                "de": "Other desc",
+                "en": "Other desc",
+                "fr": "Other desc",
+                "it": "Other desc",
+            },
+            state="active",
+            rights="Other (Open)",
+            license="http://dcat-ap.ch/vocabulary/licenses/terms_open",
+            coverage="Coverage",
+            url="http://odp.test/dataset/testdataset/resource/download/{}".format(
+                munge_filename("Other.csv")
+            ),
+        )
+
+        MockFTPStorageAdapter.filesystem = self.get_filesystem()
+        self.run_harvester(ftp_server="testserver", resource_sort_order="asc")
+
+        dataset = self.get_dataset()
+        self.assertEqual(len(dataset["resources"]), 3)
+        by_identifier = {r["identifier"]: r for r in dataset["resources"]}
+
+        self.assert_resource_format_ignore_case(
+            by_identifier[data.filename]["format"],
+            "geojson",
+            "Harvested file should copy format from fallback resource",
+        )
+        self.assertEqual(
+            by_identifier["Other.csv"]["format"],
+            "XML",
+            "Another resource on the dataset must not be updated by the harvest import",
+        )
+        self.assert_resource_format_ignore_case(
+            by_identifier["AAAResource"]["format"],
+            "geojson",
+        )
+
+    def test_replace_same_filename_leaves_other_resources_untouched(self):
+        """Replacing a harvested file must not change ``format`` on other resources."""
+        dataset = data.dataset()
+        didok_res = data.resource(dataset=dataset, filename=data.filename)
+        get_action("resource_patch")(
+            {"user": factories.Sysadmin()["name"]},
+            {"id": didok_res["id"], "format": "GEOJSON"},
+        )
+
+        factories.Resource(
+            package_id=dataset["id"],
+            identifier="Other.csv",
+            format="XML",
+            title={"de": "Other", "en": "Other", "fr": "Other", "it": "Other"},
+            name={"de": "Other", "en": "Other", "fr": "Other", "it": "Other"},
+            description={
+                "de": "Other desc",
+                "en": "Other desc",
+                "fr": "Other desc",
+                "it": "Other desc",
+            },
+            state="active",
+            rights="Other (Open)",
+            license="http://dcat-ap.ch/vocabulary/licenses/terms_open",
+            coverage="Coverage",
+            url="http://odp.test/dataset/testdataset/resource/download/{}".format(
+                munge_filename("Other.csv")
+            ),
+        )
+
+        MockFTPStorageAdapter.filesystem = self.get_filesystem()
+        self.run_harvester(ftp_server="testserver")
+
+        dataset = self.get_dataset()
+        self.assertEqual(len(dataset["resources"]), 2)
+        by_identifier = {r["identifier"]: r for r in dataset["resources"]}
+
+        self.assert_resource_format_ignore_case(
+            by_identifier[data.filename]["format"],
+            "geojson",
+        )
+        self.assertEqual(
+            by_identifier["Other.csv"]["format"],
+            "XML",
+            "Sibling resource must not be modified when another resource is replaced",
         )
 
     def test_skip_already_harvested_file(self):

--- a/ckanext/switzerland/tests/test_sbb_harvester.py
+++ b/ckanext/switzerland/tests/test_sbb_harvester.py
@@ -167,8 +167,8 @@ class TestSBBHarvester(BaseSBBHarvesterTests):
         self.assertEqual(resource["identifier"], data.filename)
         self.assert_resource_format_ignore_case(resource["format"], "geojson")
 
-    def test_new_resource_copies_format_from_fallback_old_resource(self):
-        """With no matching resource for the filename, ``format`` is taken from the first existing resource."""
+    def test_new_resource_keeps_mime_format_with_fallback_metadata(self):
+        """With no same-filename resource, ``format`` comes from MIME; other metadata may still be copied from a template resource."""
         dataset = data.dataset()
         res = data.resource(dataset=dataset)
         get_action("resource_patch")(
@@ -184,7 +184,12 @@ class TestSBBHarvester(BaseSBBHarvesterTests):
         new_res = next(
             r for r in dataset["resources"] if r["identifier"] == data.filename
         )
-        self.assert_resource_format_ignore_case(new_res["format"], "geojson")
+        self.assert_resource_format_ignore_case(new_res["format"], "csv")
+        self.assertEqual(
+            new_res["rights"],
+            res["rights"],
+            "Non-format fields should still be inherited from the fallback resource.",
+        )
 
     def test_copied_metadata_only_affects_new_harvested_resource(self):
         """Only the resource created from the FTP file gets metadata copied from the fallback; other resources are unchanged."""
@@ -225,8 +230,13 @@ class TestSBBHarvester(BaseSBBHarvesterTests):
 
         self.assert_resource_format_ignore_case(
             by_identifier[data.filename]["format"],
-            "geojson",
-            "Harvested file should copy format from fallback resource",
+            "csv",
+            "Harvested file should use MIME format, not the template resource format",
+        )
+        self.assertEqual(
+            by_identifier[data.filename]["rights"],
+            by_identifier["AAAResource"]["rights"],
+            "Non-format metadata should still be copied from the fallback template resource.",
         )
         self.assertEqual(
             by_identifier["Other.csv"]["format"],


### PR DESCRIPTION
This is mainly to preserve the format of a resource when its format got changed via the UI and gets re-harvested. This makes sure, that e.g. the chosen format `geojson` is not overriden while harvesting and a geo-preview can be created.