### PR TITLE
fix: match existing resource by its FTP filename

### DIFF
--- a/ckanext/switzerland/harvester/base_sbb_harvester.py
+++ b/ckanext/switzerland/harvester/base_sbb_harvester.py
@@ -357,7 +357,10 @@ class BaseSBBHarvester(HarvesterBase):
     # tested
     def find_resource_in_package(self, dataset, filepath):
         """
-        Identify a resource in a package by its (munged) filename
+        Identify a resource in a package by its FTP filename.
+
+        Prefer ``identifier`` (set by the harvester to the remote basename).
+        Fall back to the munged download URL basename for older resources.
 
         :param dataset: dataset dictionary
         :type dataset: dict
@@ -368,21 +371,23 @@ class BaseSBBHarvester(HarvesterBase):
         :rtype: dict
         """
         resource_meta = {}
-        if "resources" in dataset and len(dataset["resources"]):
-            # Find resource in the existing packages resource list
-            for res in dataset["resources"]:
-                # match the resource by its filename
-                match_name = munge_filename(os.path.basename(filepath))
-                if os.path.basename(res.get("url")) != match_name:
-                    continue
+        file_name = os.path.basename(filepath)
+        match_name = munge_filename(file_name)
+
+        for res in dataset.get("resources") or []:
+            if res.get("identifier") == file_name:
                 resource_meta = res
-                # there should only be one file with the same name in each dataset, so
-                # we can break
                 break
+            url_basename = os.path.basename((res.get("url") or "").split("?")[0])
+            if url_basename == match_name:
+                resource_meta = res
+                break
+
         return resource_meta
 
     def _get_dataset(self, dataset):
-        return get_action("ogdch_dataset_by_identifier")({}, {"identifier": dataset})
+        pkg = get_action("ogdch_dataset_by_identifier")({}, {"identifier": dataset})
+        return get_action("package_show")({}, {"id": pkg["id"]})
 
     def _get_mimetypes(self, filename):
         resource_formats = helpers.resource_formats()

--- a/ckanext/switzerland/tests/test_sbb_harvester.py
+++ b/ckanext/switzerland/tests/test_sbb_harvester.py
@@ -167,6 +167,24 @@ class TestSBBHarvester(BaseSBBHarvesterTests):
         self.assertEqual(resource["identifier"], data.filename)
         self.assert_equal_ignore_case(resource["format"], "geojson")
 
+    def test_find_resource_in_package_matches_by_identifier(self):
+        """Same-filename detection works when URL basename does not match."""
+        harvester = self.harvester_class()
+        dataset = {
+            "resources": [
+                {
+                    "id": "res-1",
+                    "identifier": data.filename,
+                    "format": "GEOJSON",
+                    "url": "https://cdn.example.com/unrelated-path/stale-name",
+                }
+            ]
+        }
+        matched = harvester.find_resource_in_package(
+            dataset, f"/tmp/harvest/{data.filename}"
+        )
+        self.assertEqual(matched["id"], "res-1")
+
     def test_new_resource_keeps_mime_format_with_fallback_metadata(self):
         """With no same-filename resource, ``format`` comes from MIME; other metadata may still be copied from a template resource."""
         dataset = data.dataset()


### PR DESCRIPTION
matching against the munged filename can lead to problems as we heavily rely on whether the dataset has been re-indexed in the meantime. Looking it up via package_show should make sure that any recent changes made via UI are present.